### PR TITLE
[B3081] header key not match  sdk.InvokeModeHeader bug

### DIFF
--- a/structs/header.go
+++ b/structs/header.go
@@ -35,7 +35,7 @@ const (
 	FabioRouteTagHeader   = "Host"
 	CallbackUrlHeader     = "Callback-Url"
 	RouteTagHeader        = "Route-Tag"
-	InvokeModeHeader      = "BC-Invoke-Mode"
+	InvokeModeHeader      = "Bc-Invoke-Mode"
 )
 
 // User role Header value list


### PR DESCRIPTION
Change-Id: I88d6b69c8bde65cc474400a8118dcdf593ddfddd